### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -45,8 +45,6 @@ class ItemsController < ApplicationController
     @item = Item.find_by(id: params[:id])
     if @item.nil?
       redirect_to root_path, alert: '指定された商品が見つかりません。'
-    else
-      load_dropdown_data
     end
   end
 
@@ -66,7 +64,4 @@ class ItemsController < ApplicationController
     @delivery_times = DeliveryTime.all
   end
 
-  def redirect_unless_owner
-    redirect_to root_path unless current_user && @item.user_id == current_user.id
-  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
   before_action :set_item, only: [:edit, :update, :show]
   before_action :redirect_unless_owner, only: [:edit, :update]
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -29,14 +29,12 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    load_dropdown_data
   end
 
   def update
     if @item.update(item_params)
       redirect_to @item, notice: 'Item was successfully updated.'
     else
-      load_dropdown_data
       render :edit, status: :unprocessable_entity
     end
   end
@@ -45,7 +43,11 @@ class ItemsController < ApplicationController
 
   def set_item
     @item = Item.find_by(id: params[:id])
-    redirect_to root_path, alert: '指定された商品が見つかりません。' if @item.nil?
+    if @item.nil?
+      redirect_to root_path, alert: '指定された商品が見つかりません。'
+    else
+      load_dropdown_data
+    end
   end
 
   def redirect_unless_owner

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,5 +1,5 @@
 <%# cssは商品出品のものを併用しています。
-<%# app/assets/stylesheets/items/new.css %>
+<%= app/assets/stylesheets/items/new.css %>
 
 <div class="items-sell-contents">
   <header class="items-sell-header">
@@ -7,11 +7,9 @@
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%= render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= render 'shared/error_messages', model:@item %>
 
     <%# 商品画像 %>
     <div class="img-upload">
@@ -23,7 +21,7 @@
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -33,13 +31,13 @@
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +50,12 @@
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+<%= f.collection_select :category_id, @categories, :id, :name, {}, { class: "select-box", id: "item-category" } %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+<%= f.collection_select :condition_id, @conditions, :id, :name, {}, { class: "select-box", id: "item-sales-status" } %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +71,17 @@
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+<%= f.collection_select :shipping_fee_id, @shipping_fees, :id, :name, {}, { class: "select-box", id: "item-scheduled-delivery" } %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+<%= f.collection_select :prefecture_id, @prefectures, :id, :name, {}, { class: "select-box", id: "item-prefecture" } %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+<%= f.collection_select :delivery_time_id, @delivery_times, :id, :name, {}, { class: "select-box", id: "item-scheduled-delivery" } %>
       </div>
     </div>
     <%# /配送について %>
@@ -97,11 +95,11 @@
       <div>
         <div class="price-content">
           <div class="price-text">
-            <span>価格</span>
+<label for="item_price">価格</label>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -141,7 +139,7 @@
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', root_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -139,7 +139,7 @@
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', root_path, class:"back-btn" %>
+      <%=link_to 'もどる', item_path(@item), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -50,12 +50,12 @@
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-<%= f.collection_select :category_id, @categories, :id, :name, {}, { class: "select-box", id: "item-category" } %>
+<%= f.collection_select :category_id, Category.all, :id, :name, {}, { class: "select-box", id: "item-category" } %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-<%= f.collection_select :condition_id, @conditions, :id, :name, {}, { class: "select-box", id: "item-sales-status" } %>
+<%= f.collection_select :condition_id, Condition.all, :id, :name, {}, { class: "select-box", id: "item-sales-status" } %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -71,17 +71,17 @@
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-<%= f.collection_select :shipping_fee_id, @shipping_fees, :id, :name, {}, { class: "select-box", id: "item-scheduled-delivery" } %>
+<%= f.collection_select :shipping_fee_id, ShippingFee.all, :id, :name, {}, { class: "select-box", id: "item-scheduled-delivery" } %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-<%= f.collection_select :prefecture_id, @prefectures, :id, :name, {}, { class: "select-box", id: "item-prefecture" } %>
+<%= f.collection_select :prefecture_id, Prefecture.all, :id, :name, {}, { class: "select-box", id: "item-prefecture" } %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-<%= f.collection_select :delivery_time_id, @delivery_times, :id, :name, {}, { class: "select-box", id: "item-scheduled-delivery" } %>
+<%= f.collection_select :delivery_time_id, DeliveryTime.all, :id, :name, {}, { class: "select-box", id: "item-scheduled-delivery" } %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,7 +25,7 @@
 
 <% if user_signed_in? %>
   <% if current_user == @item.user %>
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+    <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
     <% else %>


### PR DESCRIPTION
# What
商品情報編集機能の実装
# Why
商品情報編集機能の実装のため

・ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/3a0cd62eaae52cce1f511fe371320777
・必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/5adee465e9a23a6e716bed9b6897e906
・入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/fe4a4c80f2ad32a1e52d7f4b545dd458
・何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/d7ea5b1d45a869f4487e2f754e9b1df5
・ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/c71f0c52a8b3b63f75468c366188d626
・ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/cfca07201bb11d5d4c086e484693fea4
・商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/3f4d7e578cc2b313d087e804cf293072
